### PR TITLE
.tabs does not work with -a

### DIFF
--- a/index.js
+++ b/index.js
@@ -1012,7 +1012,7 @@ ChromeREPL.prototype = {
   },
 
   listTabs: function() {
-    this.client.listTabs(this.host, this.options.port, function(err, tabs) {
+    this.client.listTabs(this.options.host, this.options.port, function(err, tabs) {
       if (err) throw err;
 
       var strs = "";


### PR DESCRIPTION
It looks like that when the cli is run with `crconsole -a ...(ip address)`, it is falling back to use localhost.

```
node_modules/crconsole/index.js:667
      if (err) throw err;
               ^

Error: connect ECONNREFUSED 127.0.0.1:9222
    at Object.exports._errnoException (util.js:890:11)
    at exports._exceptionWithHostPort (util.js:913:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1059:14)
```

This patch should fix the issue.